### PR TITLE
Orientation fix for ios doc scan library

### DIFF
--- a/Source/Public/IRLScannerViewController.m
+++ b/Source/Public/IRLScannerViewController.m
@@ -317,6 +317,12 @@
              cropViewController.delegate = self;
              cropViewController.aspectRatioPickerButtonHidden = YES;
              cropViewController.modalTransitionStyle = UIModalTransitionStyleCrossDissolve;
+             
+             switch ([[UIApplication sharedApplication] statusBarOrientation]) {
+                case UIInterfaceOrientationLandscapeLeft: cropViewController.angle = 90; break;
+                case UIInterfaceOrientationLandscapeRight: cropViewController.angle = -90; break;
+             }
+             
              [self presentViewController:cropViewController animated:YES completion:nil];
              
          }];


### PR DESCRIPTION
In landscape orientation after a manual scan the orientation of the image is not upright. 

This fixes it.

Thanks for this awesome library. Let me know if there are changes required.